### PR TITLE
Canvas: fix native handling and max_width argument

### DIFF
--- a/opal/browser/canvas/text.rb
+++ b/opal/browser/canvas/text.rb
@@ -11,30 +11,42 @@
 module Browser; class Canvas
 
 class Text
+  include Native
+
   attr_reader :context
 
   def initialize(context)
     @context = context
+
+    super @context.to_n
   end
 
   def measure(text)
     `#@native.measureText(text)`
   end
 
-  def fill(text, x = nil, y = nil, max_width = undefined)
+  def fill(text, x = nil, y = nil, max_width = nil)
     x ||= 0
     y ||= 0
 
-    `#@native.fillText(text, x, y, max_width)`
+    if max_width
+      `#{@native}.fillText(text, x, y, max_width)`
+    else
+      `#{@native}.fillText(text, x, y)`
+    end
 
     @context
   end
 
-  def stroke(text, x = nil, y = nil, max_width = undefined)
+  def stroke(text, x = nil, y = nil, max_width = nil)
     x ||= 0
     y ||= 0
 
-    `#@native.strokeText(text, x, y, max_width)`
+    if max_width
+      `#@native.strokeText(text, x, y, max_width)`
+    else
+      `#@native.strokeText(text, x, y)`
+    end
 
     @context
   end


### PR DESCRIPTION
This PR adds the missing `Native` include and a check for the `max_width` argument in `#fill` and `#stroke` with a condition.

The check for `max_width` was necessary, otherwise it would be considered to be `0` when not passed, causing no text to be rendered, which doesn't seem to be the expected behaviour, as the limit should only be applied if provided.

Tested in `Chrome 31.0.1650.63`.
