### PR TITLE
lib: add 'opal-browser.rb' in opal/

### DIFF
--- a/opal/opal-browser.rb
+++ b/opal/opal-browser.rb
@@ -1,0 +1,1 @@
+require 'browser'


### PR DESCRIPTION
That should help people who blindly tries to require using the same name as the lib.