### PR TITLE
Aliases for write

### DIFF
--- a/opal/browser/socket.rb
+++ b/opal/browser/socket.rb
@@ -106,6 +106,8 @@ class Socket
   def write(data)
     `#@native.send(#{data.to_n})`
   end
+  alias << write
+  alias send write
 
   # Close the socket.
   #


### PR DESCRIPTION
People who always used `send` in javascript will be confused about `NoMethodError: undefined method` exception :)
And people who worked with sockets in Ruby will definitely expect a `<<` method.