### PR TITLE
Explicitly forward events to Event::Progress

### DIFF
--- a/opal/browser/http/request.rb
+++ b/opal/browser/http/request.rb
@@ -195,10 +195,10 @@ class Request
   #
   # @yieldparam response [Response] the response for the event
   def on(what, *, &block)
-    if STATES.include?(what)
-      @callbacks[what] << block
-    else
+    if %w[progress load loadend loadstart].include?(what)
       super
+    else
+      @callbacks[what] << block
     end
   end
 

--- a/opal/browser/http/request.rb
+++ b/opal/browser/http/request.rb
@@ -195,10 +195,10 @@ class Request
   #
   # @yieldparam response [Response] the response for the event
   def on(what, *, &block)
-    if %w[progress load loadend loadstart].include?(what)
-      super
-    else
+    if STATES.include?(what) || %w[success failure].include?(what) || Integer === what
       @callbacks[what] << block
+    else
+      super
     end
   end
 


### PR DESCRIPTION
@meh The problem was the HTTP::Request object allows other callbacks that are not in the STATES constant. Particularly, it fires 'success' or 'failure' when a request is complete based on the response code. Furthermore, it looks like HTTP::Request also will fire callbacks for specific response codes:
```ruby
request.on '200' do
  ...
end
```

So I swapped the filter for callbacks based on what Event::Progress handles. Working much better now.