### PR TITLE
Fix Browser::Cookies: reading of cookies

### DIFF
--- a/opal/browser/cookies.rb
+++ b/opal/browser/cookies.rb
@@ -41,8 +41,8 @@ class Cookies
 
     return if matches.empty?
 
-    result = matches.map {|cookie|
-      JSON.parse(cookie.match(/^.*?=(.*)$/)[1].decode_uri_component)
+    result = matches.flatten.map {|value|
+      JSON.parse(value.decode_uri_component)
     }
 
     result.length == 1 ? result.first : result


### PR DESCRIPTION
So it looks like the .scan regexp will result in an array of array structure:

```
>> matches = "a=1;b=2;c=3".scan(/b=([^;]*)/)
=> [["2"]]
>> matches.flatten
=> ["2"]
>> 
```

This fix flattens that structure and runs decode_uri_component on each value