### PR TITLE
Add: click method to Element class

### DIFF
--- a/opal/browser/effects.rb
+++ b/opal/browser/effects.rb
@@ -45,6 +45,11 @@ class Element
   def focused?
     `#@native.hasFocus`
   end
+
+  # Click the element. it fires the element's click event.
+  def click
+    `#@native.click()`
+  end
 end
 
 end; end


### PR DESCRIPTION
I added `click`method to Element class.
When `click` method is used with supported elements (such as an `<input>`), it fires the element's click event.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click