### PR TITLE
Small fixes and updates

### DIFF
--- a/opal/browser/audio.rb
+++ b/opal/browser/audio.rb
@@ -3,7 +3,7 @@ require 'browser/audio/node'
 module Browser; module Audio
 
 class Context
-  include Native
+  include Native::Wrapper
 
   alias_native :destination
   alias_native :listener

--- a/opal/browser/audio/node.rb
+++ b/opal/browser/audio/node.rb
@@ -1,7 +1,7 @@
 module Browser; module Audio; module Node
 
 class Base
-  include Native
+  include Native::Wrapper
 
   def initialize(native)
     @native = native

--- a/opal/browser/audio/param_schedule.rb
+++ b/opal/browser/audio/param_schedule.rb
@@ -1,7 +1,7 @@
 module Browser; module Audio
 
   class ParamSchedule
-    include Native
+    include Native::Wrapper
 
     alias_native :cancel, :cancelScheduledValues
 

--- a/opal/browser/canvas.rb
+++ b/opal/browser/canvas.rb
@@ -8,7 +8,7 @@ require 'browser/canvas/gradient'
 module Browser
 
 class Canvas
-  include Native
+  include Native::Wrapper
 
   attr_reader :element, :style, :text
 

--- a/opal/browser/canvas/data.rb
+++ b/opal/browser/canvas/data.rb
@@ -17,7 +17,7 @@ class Data
     data
   end
 
-  include Native
+  include Native::Wrapper
 
   attr_reader :x, :y, :width, :height
 

--- a/opal/browser/canvas/gradient.rb
+++ b/opal/browser/canvas/gradient.rb
@@ -1,7 +1,7 @@
 module Browser; class Canvas
 
 class Gradient
-  include Native
+  include Native::Wrapper
 
   attr_reader :context
 

--- a/opal/browser/canvas/style.rb
+++ b/opal/browser/canvas/style.rb
@@ -1,7 +1,7 @@
 module Browser; class Canvas
 
 class StyleObject
-  include Native
+  include Native::Wrapper
 
   attr_reader :context
 

--- a/opal/browser/canvas/text.rb
+++ b/opal/browser/canvas/text.rb
@@ -1,7 +1,7 @@
 module Browser; class Canvas
 
 class Text
-  include Native
+  include Native::Wrapper
 
   attr_reader :context
 

--- a/opal/browser/console.rb
+++ b/opal/browser/console.rb
@@ -6,7 +6,7 @@ module Browser
 #
 # @see https://developer.mozilla.org/en-US/docs/Web/API/console
 class Console
-  include Native
+  include Native::Wrapper
 
   # Clear the console.
   def clear

--- a/opal/browser/css/declaration.rb
+++ b/opal/browser/css/declaration.rb
@@ -1,7 +1,7 @@
 module Browser; module CSS
 
 class Declaration
-  include Native
+  include Native::Wrapper
   include Enumerable
 
   def rule

--- a/opal/browser/css/rule.rb
+++ b/opal/browser/css/rule.rb
@@ -1,7 +1,7 @@
 module Browser; module CSS
 
 class Rule
-  include Native
+  include Native::Wrapper
 
   STYLE_RULE               = 1
   CHARSET_RULE             = 2

--- a/opal/browser/css/style_sheet.rb
+++ b/opal/browser/css/style_sheet.rb
@@ -1,7 +1,7 @@
 module Browser; module CSS
 
 class StyleSheet
-  include Native
+  include Native::Wrapper
 
   def initialize(what)
     if what.is_a? DOM::Element

--- a/opal/browser/database/sql.rb
+++ b/opal/browser/database/sql.rb
@@ -27,7 +27,7 @@ class SQL
     Timeout    = Class.new(self)
   end
 
-  include Native
+  include Native::Wrapper
 
   # @return [String] the name of the database
   attr_reader :name
@@ -87,7 +87,7 @@ class SQL
 
   # Allows you to make changes to the database or read data from it.
   class Transaction
-    include Native
+    include Native::Wrapper
 
     # @return [Database] the database the transaction has been created from
     attr_reader :database
@@ -129,7 +129,7 @@ class SQL
   end
 
   class Result
-    include Native
+    include Native::Wrapper
 
     # @return [Transaction] the transaction the result came from
     attr_reader :transaction

--- a/opal/browser/dom/attribute.rb
+++ b/opal/browser/dom/attribute.rb
@@ -2,7 +2,7 @@ module Browser; module DOM
 
 # Encapsulates an {Element} attribute.
 class Attribute
-  include Native
+  include Native::Wrapper
 
   # @!attribute [r] name
   # @return [String] the name of the attribute

--- a/opal/browser/dom/element/input.rb
+++ b/opal/browser/dom/element/input.rb
@@ -21,11 +21,11 @@ class Input < Element
   end
 
   def check!
-    `#@native.checked = 'checked';`
+    `#@native.checked = 'checked'`
   end
 
   def uncheck!
-    `#@native.checked = '';`
+    `#@native.checked = ''`
   end
 
   def clear

--- a/opal/browser/dom/mutation_observer.rb
+++ b/opal/browser/dom/mutation_observer.rb
@@ -9,11 +9,11 @@ class MutationObserver
     Browser.supports? :MutationObserver
   end
 
-  include Native
+  include Native::Wrapper
 
   # Encapsulates a recorded change.
   class Record
-    include Native
+    include Native::Wrapper
 
     # @!attribute [r] type
     # @return [:attributes, :tree, :cdata] the type of the recorded change

--- a/opal/browser/dom/node.rb
+++ b/opal/browser/dom/node.rb
@@ -4,7 +4,7 @@ module Browser; module DOM
 #
 # @see https://developer.mozilla.org/en-US/docs/Web/API/Node
 class Node
-  include Native
+  include Native::Wrapper
 
   ELEMENT_NODE                = 1
   ATTRIBUTE_NODE              = 2

--- a/opal/browser/event/base.rb
+++ b/opal/browser/event/base.rb
@@ -1,11 +1,11 @@
 module Browser
 
 class Event
-  include Native
+  include Native::Wrapper
 
   # @see https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
   class Definition
-    include Native
+    include Native::Wrapper
 
     # @private
     def self.new(&block)

--- a/opal/browser/event/drag.rb
+++ b/opal/browser/event/drag.rb
@@ -8,7 +8,7 @@ class Drag < Event
 
   class Definition < Definition
     class Client
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.clientX = #{value}`
@@ -20,7 +20,7 @@ class Drag < Event
     end
 
     class Screen
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.screenX = #{value}`

--- a/opal/browser/event/mouse.rb
+++ b/opal/browser/event/mouse.rb
@@ -7,7 +7,7 @@ class Mouse < UI
 
   class Definition < UI::Definition
     class Client
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.clientX = #{value}`
@@ -19,7 +19,7 @@ class Mouse < UI
     end
 
     class Layer
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.layerX = #{value}`
@@ -31,7 +31,7 @@ class Mouse < UI
     end
 
     class Offset
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.offsetX = #{value}`
@@ -43,7 +43,7 @@ class Mouse < UI
     end
 
     class Page
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.pageX = #{value}`
@@ -55,7 +55,7 @@ class Mouse < UI
     end
 
     class Screen
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.screenX = #{value}`
@@ -67,7 +67,7 @@ class Mouse < UI
     end
 
     class Ancestor
-      include Native
+      include Native::Wrapper
 
       def x=(value)
         `#@native.x = #{value}`

--- a/opal/browser/event_source.rb
+++ b/opal/browser/event_source.rb
@@ -9,7 +9,7 @@ class EventSource
     Browser.supports? :EventSource
   end
 
-  include Native
+  include Native::Wrapper
   include Event::Target
 
   target {|value|

--- a/opal/browser/history.rb
+++ b/opal/browser/history.rb
@@ -11,7 +11,7 @@ class History
     Browser.supports? 'History'
   end
 
-  include Native
+  include Native::Wrapper
 
   # @!attribute [r] length
   # @return [Integer] how many items are in the history

--- a/opal/browser/http/request.rb
+++ b/opal/browser/http/request.rb
@@ -1,7 +1,7 @@
 module Browser; module HTTP
 
 class Request
-  include Native
+  include Native::Wrapper
   include Event::Target
 
   # Default headers.

--- a/opal/browser/http/response.rb
+++ b/opal/browser/http/response.rb
@@ -4,7 +4,7 @@ module Browser; module HTTP
 
 # Represents an HTTP response.
 class Response
-  include Native
+  include Native::Wrapper
 
   Status = Struct.new(:code, :text)
 

--- a/opal/browser/location.rb
+++ b/opal/browser/location.rb
@@ -4,7 +4,7 @@ module Browser
 #
 # @see https://developer.mozilla.org/en-US/docs/Web/API/Location
 class Location
-  include Native
+  include Native::Wrapper
 
   # Change the location.
   #

--- a/opal/browser/navigator.rb
+++ b/opal/browser/navigator.rb
@@ -4,7 +4,7 @@ module Browser
 #
 # @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator
 class Navigator
-  include Native
+  include Native::Wrapper
 
   Version = Struct.new(:major, :minor, :build)
   Product = Struct.new(:name, :version)
@@ -12,7 +12,7 @@ class Navigator
 
   # Representation of a MIME type.
   class MimeType
-    include Native
+    include Native::Wrapper
 
     # @!attribute [r] plugin
     # @return [Plugin] the plugin for the MIME type

--- a/opal/browser/screen.rb
+++ b/opal/browser/screen.rb
@@ -4,7 +4,7 @@ module Browser
 #
 # @see https://developer.mozilla.org/en-US/docs/Web/API/Window.screen
 class Screen
-  include Native
+  include Native::Wrapper
   include Event::Target
 
   target {|value|

--- a/opal/browser/socket.rb
+++ b/opal/browser/socket.rb
@@ -9,7 +9,7 @@ class Socket
     Browser.supports? :WebSocket
   end
 
-  include Native
+  include Native::Wrapper
   include IO::Writable
   include Event::Target
 

--- a/opal/browser/support.rb
+++ b/opal/browser/support.rb
@@ -178,7 +178,13 @@ module Browser
         `"onreadystatechange" in window.document.createElement("script")`
 
       when 'Event.constructor'
-        `try{new MouseEvent("click");return true;} catch (e){return false;}`
+        begin
+          `new MouseEvent("click")`
+
+          true
+        rescue
+          false
+        end
 
       when 'Event.create'
         defined?(`document.createEvent`)

--- a/opal/browser/window.rb
+++ b/opal/browser/window.rb
@@ -30,7 +30,7 @@ class Window
     }
   end
 
-  include Native
+  include Native::Wrapper
   include Event::Target
 
   target {|value|


### PR DESCRIPTION
1. At least Opal 1.0.0 generated incorrect Javascript since the fix for IE11 has been committed
2. Two x-strings were terminated by semicolons
3. As of Opal 1.0.0, including Native has been deprecated, this commit replaces all occurrences of that with including Native::Wrapper. You may want to postpone this patch if you want to keep compatibility with older versions of Opal