### PR TITLE
Seventh composite pull request

### DIFF
--- a/opal/browser/dom/document.rb
+++ b/opal/browser/dom/document.rb
@@ -50,7 +50,7 @@ class Document < Element
     else
       elem = `#@native.createElement(name, #{opts.to_n})`
     end
-    
+
     if options[:classes]
       `#{elem}.className = #{Array(options[:classes]).join(" ")}`
     end
@@ -61,11 +61,8 @@ class Document < Element
 
     if options[:attrs]
       options[:attrs].each do |k,v|
-        %x`
-          var attr = #@native.createAttribute(#{k});
-          attr.value = #{v};
-          #{elem}.setAttributeNode(attr);
-        `
+        next unless v
+        `#{elem}.setAttribute(#{k}, #{v})`
       end
     end
 

--- a/opal/browser/dom/document.rb
+++ b/opal/browser/dom/document.rb
@@ -137,6 +137,12 @@ class Document < Element
     `#@native.readyState === "complete" || #@native.readyState === "interactive"`
   end
 
+  # @!attribute referrer
+  # @return [String] the referring document, or empty string if direct access
+  def referrer
+    `#@native.referrer`
+  end
+
   # @!attribute root
   # @return [Element?] the root element of the document
   def root

--- a/opal/browser/dom/element.rb
+++ b/opal/browser/dom/element.rb
@@ -502,6 +502,18 @@ class Element < Node
     Size.new(self, *inc)
   end
 
+  # Toggle class names of the element.
+  #
+  # @param names [Array<String>] class names to toggle
+  #
+  # @return [self]
+  def toggle_class(*names)
+    to_remove, to_add = names.partition { |name| class_names.include? name }
+
+    add_class(*to_add)
+    remove_class(*to_remove)
+  end
+
   # @!attribute width
   # @return [Integer] the width of the element
   def width

--- a/opal/browser/dom/element/attributes.rb
+++ b/opal/browser/dom/element/attributes.rb
@@ -71,6 +71,14 @@ class Attributes
     end
   end
 
+  # Deletes an attribute with a given name
+  # @return [String] an attribute value before deletion
+  def delete(name)
+    attr = self[name]
+    self[name] = nil
+    attr
+  end
+
   include Enumerable
 
   def each(&block)

--- a/opal/browser/dom/element/attributes.rb
+++ b/opal/browser/dom/element/attributes.rb
@@ -32,9 +32,17 @@ class Attributes
       end
 
       if namespace = options[:namespace] || @namespace
-        `#@native.setAttributeNS(#{namespace.to_s}, #{name.to_s}, #{value})`
+        if value
+          `#@native.setAttributeNS(#{namespace.to_s}, #{name.to_s}, #{value})`
+        else
+          `#@native.removeAttributeNS(#{namespace.to_s}, #{name.to_s})`
+        end
       else
-        `#@native.setAttribute(#{name.to_s}, #{value.to_s})`
+        if value
+          `#@native.setAttribute(#{name.to_s}, #{value.to_s})`
+        else
+          `#@native.removeAttribute(#{name.to_s})`
+        end
       end
     end
   else
@@ -48,9 +56,17 @@ class Attributes
 
     def []=(name, value, options = {})
       if namespace = options[:namespace] || @namespace
-        `#@native.setAttributeNS(#{namespace.to_s}, #{name.to_s}, #{value})`
+        if value
+          `#@native.setAttributeNS(#{namespace.to_s}, #{name.to_s}, #{value})`
+        else
+          `#@native.removeAttributeNS(#{namespace.to_s}, #{name.to_s})`
+        end
       else
-        `#@native.setAttribute(#{name.to_s}, #{value.to_s})`
+        if value
+          `#@native.setAttribute(#{name.to_s}, #{value.to_s})`
+        else
+          `#@native.removeAttribute(#{name.to_s})`
+        end
       end
     end
   end

--- a/opal/browser/dom/element/data.rb
+++ b/opal/browser/dom/element/data.rb
@@ -60,13 +60,22 @@ class Data
   end
 
   def []=(name, value)
-    if value.respond_to? :to_str
+    `delete #@native.$data[name]`
+    if [true, false, nil].include?(value)
+      @element["data-#{name}"] = value
+    elsif value.respond_to? :to_str
       @element["data-#{name}"] = value.to_str
     elsif value.respond_to? :to_int
       @element["data-#{name}"] = value.to_int.to_s
     else
       `#@native.$data[name] = value`
     end
+  end
+
+  def delete(name)
+    data = self[name]
+    self[name] = nil
+    data
   end
 end
 

--- a/opal/browser/form_data.rb
+++ b/opal/browser/form_data.rb
@@ -172,7 +172,13 @@ class FormData
 
   # Iterate over all elements of this FormData
   def each(&block)
-    Native(`#@native.getAll()`).each(&block)
+    hash = {}
+    %x{
+      for (var pair of #@native.entries()) {
+        #{hash[`pair[0]`] = `pair[1]`}
+      }
+    }
+    hash.each(&block)
     self
   end
 

--- a/opal/browser/history.rb
+++ b/opal/browser/history.rb
@@ -50,7 +50,7 @@ class History
   # @!attribute [r] current
   # @return [String] the current item
   def current
-    $window.location.path
+    $window.location.full_path
   end
 
   # @!attribute [r] state

--- a/opal/browser/http/response.rb
+++ b/opal/browser/http/response.rb
@@ -47,6 +47,10 @@ class Response
     !success?
   end
 
+  # @!attribute [r] url
+  # @return [String] the response URL (after redirects)
+  alias_native :url, :responseURL
+
   # @!attribute [r] text
   # @return [String] the response body as text
   def text

--- a/opal/browser/location.rb
+++ b/opal/browser/location.rb
@@ -66,6 +66,12 @@ class Location
   # @return [String] the query part of the location URI
   alias_native :query, :search
   alias_native :query=, :search=
+
+  # Returns the full path of the location URI, including
+  # the query string and fragment, eg. /site?a=b#c
+  def full_path
+    path + query + fragment
+  end
 end
 
 class Window


### PR DESCRIPTION
Of the things that I want to document, maybe this should first come to mind:

```ruby
d = DOM { input(type: "text") }
d["required"] = true # Worked
d["required"] = false # Had an unintuitive behavior before
d.attributes.delete("required") # Alternative syntax

# Also:
req = false
d = DOM { input(type: "text", required: req) } # This works now
# Used to require this before:
d = DOM {
  h = {type: "text"}
  h.merge!(required: "") if req
  input(h)
}
```

In general I develop opal-browser while developing an application, so those features come as what I miss while developing it.