### PR TITLE
Refactor the cookie module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.3.2
+* Cookie: refactor the module
+  * Note in documentation it's available as `$document.cookies` and it's the preferred way to access it
+  * Always encode a cookie with JSON, unless a new parameter `raw:` is provided
+
+## 0.3.1
+* Element#inner_dom: Reduce flickering - first build tree, then insert it
+* NodeSet#to_a to be aliased to #to_ary

--- a/opal/browser/version.rb
+++ b/opal/browser/version.rb
@@ -1,3 +1,3 @@
 module Browser
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
The old logic was a bit silly at least.

```
cookies = $document.cookies
cookies['x'] = 'test'
cookies['x'] # JSON::ParserError
```

There was a test if a set value is a String and if it is, then it wasn't serialized with JSON. But when reading, it always used JSON.parse.

While this in theory breaks compatibility, it doesn't, because it didn't work before.