### PR TITLE
Correct an Opal v1.4 compatibility issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,39 +16,23 @@ jobs:
       matrix:
         combo:
           - name: Chromium/Linux/Opal-master
-            browser: chrome
-            os: ubuntu-latest
             opal: master
+          - name: Chromium/Linux/Opal-1.4
+            opal: 1.4
           - name: Chromium/Linux/Opal-1.3/PromiseV2
-            browser: chrome
-            os: ubuntu-latest
             opal: 1.3
             promise: v2
           - name: Chromium/Linux/Opal-1.3
-            browser: chrome
-            os: ubuntu-latest
             opal: 1.3
-          - name: Chromium/Linux/Opal-1.2
-            browser: chrome
-            os: ubuntu-latest
-            opal: 1.2
           - name: Chromium/Linux/Opal-1.0
-            browser: chrome
-            os: ubuntu-latest
             opal: '1.0'
           - name: Chromium/Linux/Ruby-2.7
-            browser: chrome
-            os: ubuntu-latest
             ruby: 2.7
           - name: Chromium/Linux/Ruby-2.6
-            browser: chrome
-            os: ubuntu-latest
             ruby: 2.6
           - name: Firefox/Linux
             browser: gecko
-            os: ubuntu-latest
           - name: Chromium/Windows
-            browser: chrome
             os: windows-latest
           - name: Firefox/Windows
             browser: gecko
@@ -57,7 +41,6 @@ jobs:
             browser: edge
             os: windows-latest
           - name: Chromium/macOS
-            browser: chrome
             os: macos-latest
           - name: Firefox/macOS
             browser: gecko
@@ -66,7 +49,7 @@ jobs:
             browser: safari
             os: macos-latest
 
-    runs-on: ${{ matrix.combo.os }}  
+    runs-on: ${{ matrix.combo.os || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -81,15 +64,15 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ./vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.2.0.beta1' }}-${{ github.ref }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.3' }}-${{ github.ref }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.2.0.beta1' }}-${{ github.ref }}
-            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.2.0.beta1' }}-master
-            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.2.0.beta1' }}-
+            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.3' }}-${{ github.ref }}
+            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.3' }}-master
+            ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-${{ matrix.combo.opal || '1.3' }}-
             ${{ runner.os }}-${{ matrix.combo.ruby || '3.0' }}-gems-
       - name: bundle install
         run: |
           bundle config path $PWD/vendor/bundle
           bundle install --jobs 4 --retry 3
           bundle clean
-      - run: bundle exec rake selenium_${{ matrix.combo.browser }}
+      - run: bundle exec rake selenium_${{ matrix.combo.browser || 'chrome' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+* Compatibility fix for Opal 1.4
+
 ## 0.3.2
 * Cookie: refactor the module
   * Note in documentation it's available as `$document.cookies` and it's the preferred way to access it

--- a/opal/browser/support.rb
+++ b/opal/browser/support.rb
@@ -75,14 +75,16 @@ module Browser
       when 'Window.send (Asynchronous)'
         if defined?(`window.postMessage`) && !defined?(`window.importScripts`)
           %x{
-            var ok  = true,
-                old = window.onmessage;
+            (function() {
+              var ok  = true,
+                  old = window.onmessage;
 
-            window.onmessage = function() { ok = false; };
-            window.postMessage("", "*")
-            window.onmessage = old;
+              window.onmessage = function() { ok = false; };
+              window.postMessage("", "*")
+              window.onmessage = old;
 
-            return ok;
+              return ok;
+            })()
           }
         end
 
@@ -106,10 +108,12 @@ module Browser
 
       when 'Attr.isId'
         %x{
-          var div = document.createElement('div');
-              div.setAttribute('id', 'xxxxxxxxxxxxx');
+          (function() {
+            var div = document.createElement('div');
+                div.setAttribute('id', 'xxxxxxxxxxxxx');
 
-          return typeof(div.attributes['id'].isId) !== "undefined";
+            return typeof(div.attributes['id'].isId) !== "undefined";
+          })()
         }
 
       when 'Element.addBehavior'
@@ -117,34 +121,42 @@ module Browser
 
       when 'Element.className'
         %x{
-          var div = document.createElement("div");
-              div.setAttribute('className', 'x');
+          (function() {
+            var div = document.createElement("div");
+                div.setAttribute('className', 'x');
 
-          return div.className === 'x';
+            return div.className === 'x';
+          })()
         }
 
       when 'Element.class'
         %x{
-          var div = document.createElement("div");
-              div.setAttribute('class', 'x');
+          (function() {
+            var div = document.createElement("div");
+                div.setAttribute('class', 'x');
 
-          return div.className === 'x';
+            return div.className === 'x';
+          })()
         }
 
       when 'Element.for'
         %x{
-          var label = document.createElement("label");
-              label.setAttribute('for', 'x');
+          (function() {
+            var label = document.createElement("label");
+                label.setAttribute('for', 'x');
 
-          return label.htmlFor === 'x';
+            return label.htmlFor === 'x';
+          })()
         }
 
       when 'Element.htmlFor'
         %x{
-          var label = document.createElement("label");
-              label.setAttribute('htmlFor', 'x');
+          (function() {
+            var label = document.createElement("label");
+                label.setAttribute('htmlFor', 'x');
 
-          return label.htmlFor === 'x';
+            return label.htmlFor === 'x';
+          })()
         }
 
       when 'Element.clientSize'

--- a/opal/browser/version.rb
+++ b/opal/browser/version.rb
@@ -1,3 +1,3 @@
 module Browser
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
This is related to our output size fixes in Opal 1.4. This piece of code is collapsed into a ternary expression. It would be best if we could correct this behavior in Opal, but I don't think we will before the release... It's a hard problem to detect a statement in an x-string and if expression is expected to wrap it in a closure (aka IIFE). And also there's a lot of incompatibilities possible either way.